### PR TITLE
Move package under gusta namespace, remove author field from package.json

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 ayan4m1 <andrew@bulletlogic.com>
+Copyright (c) 2019 Gusta Project <contact@mixnjuice.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "gusta-api",
+  "name": "@gusta/api",
   "version": "0.1.0",
   "description": "A simple REST API for recipe and flavor information",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "gusta-api",
   "version": "0.1.0",
   "description": "A simple REST API for recipe and flavor information",
-  "author": "ayan4m1 <andrew@bulletlogic.com>",
   "license": "MIT",
   "scripts": {
     "build": "gulp",


### PR DESCRIPTION
I had left the default info in the author field during `npm init` - now that this repo is part of the organization I feel like we should do what other large projects do and have no author information in the package.json. At some point in the future we can create a separate document with a list of contributors when necessary.

This also changes the package name to move it under the `@gusta` npm namespace/organization.