### PR TITLE
Add missing preparations_diluents table

### DIFF
--- a/schema/07.do.preparations-diluents.sql
+++ b/schema/07.do.preparations-diluents.sql
@@ -1,0 +1,16 @@
+alter table preparation
+  add column id bigint not null default nextval('preparation_id_seq'),
+  alter column recipe_id drop default,
+  drop constraint pk_preparation,
+  add constraint pk_preparation primary key (id);
+
+create table preparations_diluents (
+  preparation_id bigint not null,
+  diluent_id int not null,
+  millipercent numeric(4, 4) not null,
+  nicotine_concentration numeric(4, 4) not null default 0,
+
+  constraint pk_preparations_diluents primary key (preparation_id, diluent_id),
+  constraint fk1_preparations_diluents foreign key (preparation_id) references preparation (id),
+  constraint fk2_preparations_diluents foreign key (diluent_id) references diluent (id)
+);

--- a/schema/07.undo.preparations-diluents.sql
+++ b/schema/07.undo.preparations-diluents.sql
@@ -1,0 +1,7 @@
+drop table preparations_diluents;
+
+alter table preparation
+  drop constraint pk_preparation,
+  drop column id,
+  add constraint pk_preparation primary key (recipe_id, user_id),
+  alter column recipe_id set default nextval('preparation_id_seq');

--- a/src/models/preparationsDiluents.js
+++ b/src/models/preparationsDiluents.js
@@ -1,0 +1,48 @@
+module.exports = (sequelize, DataTypes) => {
+  const PreparationsDiluents = sequelize.define(
+    'PreparationsDiluents',
+    {
+      recipeId: {
+        type: DataTypes.BIGINT,
+        allowNull: false,
+        primaryKey: true,
+        references: {
+          model: sequelize.Recipe,
+          key: 'id'
+        }
+      },
+      diluentId: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        primaryKey: true,
+        references: {
+          model: sequelize.Diluent,
+          key: 'id'
+        }
+      },
+      millipercent: {
+        type: DataTypes.DECIMAL,
+        allowNull: false
+      },
+      nicotineConcentration: {
+        type: DataTypes.DECIMAL,
+        allowNull: false,
+        defaultValue: 0
+      }
+    },
+    {
+      sequelize,
+      underscored: true,
+      tableName: 'recipes_diluents',
+      createdAt: false,
+      updatedAt: false
+    }
+  );
+
+  PreparationsDiluents.associate = function(models) {
+    this.belongsTo(models.Preparation, { foreignKey: 'preparationId' });
+    this.belongsTo(models.Diluent, { foreignKey: 'diluentId' });
+  };
+
+  return PreparationsDiluents;
+};


### PR DESCRIPTION
This PR makes a few schema changes and adds a missing model.

The `preparation` table did not have a correct primary key, that is fixed [here](https://github.com/gusta-project/api/compare/master...ayan4m1:feature/prep-diluents?expand=1#diff-6fea68894039b7c348b2dbe3ad3346bdR1). Next I [created](https://github.com/gusta-project/api/compare/master...ayan4m1:feature/prep-diluents?expand=1#diff-6fea68894039b7c348b2dbe3ad3346bdR7) a table that was in my ERD but missing from the SQL. Finally, I [added](https://github.com/gusta-project/api/compare/master...ayan4m1:feature/prep-diluents?expand=1#diff-520f494942e311575bd137325f64dc03R1) a skeleton model for the new table.