### PR TITLE
Add authentication bypass mechanism to app config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Gusta API
 
-This repository is a proof-of-concept of a simple REST API written using Node.js.
+This repository contains the express-based API that powers the Gusta Project frontend.
 
 ## libraries
 
 - [Express](https://expressjs.com/)
-- JWT-based authentication provided by [passport-jwt](https://www.npmjs.com/package/passport-jwt)
-- [pg](https://github.com/brianc/node-postgres) as a PostgreSQL client
+- [Sequelize](http://docs.sequelizejs.com/)
+- [passport-http-bearer](https://github.com/jaredhanson/passport-http-bearer)
 - [postgrator](https://github.com/rickbergfalk/postgrator) to handle SQL migrations
 
 ## usage
@@ -27,10 +27,10 @@ Now, in a shell:
 
 ```sh
 npm install
-cp .flavorrc.default.yml .flavorrc.yml
+cp .env.default .env
 ```
 
-Configuration resides in `.flavorrc.yml`. Edit this file and supply your database information. Finally:
+Configuration resides in `.env`. Edit this file and supply your database information. Finally:
 
 ```sh
 npm run migrate

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ npm start
 
 You can use `npm run migrate 0` to revert all database migrations, or `npm run migrate X` to migrate to version X.
 
+## authentication
+
+Some requests require a bearer token by default. If you start the server with the `API_TOKEN_VALIDATE` environment variable set to `false` the token check will be bypassed. For convience you can run `npm run start-mock` to start the API up with anonymous auth enabled.
+
 ## docker
 
 Simply run `docker-compose up` from the source root. Use the `--no-start` option to create the containers without starting them in interactive mode.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2629,6 +2629,16 @@
         "parse-json": "^4.0.0"
       }
     },
+    "cross-env": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.2.0.tgz",
+      "integrity": "sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^6.0.5",
+        "is-windows": "^1.0.0"
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8128,6 +8128,14 @@
         "pause": "0.0.1"
       }
     },
+    "passport-anonymous": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/passport-anonymous/-/passport-anonymous-1.0.1.tgz",
+      "integrity": "sha1-JB43J07ETft/bK0jS0HEODhrwRc=",
+      "requires": {
+        "passport-strategy": "1.x.x"
+      }
+    },
     "passport-http-bearer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/passport-http-bearer/-/passport-http-bearer-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "develop": "gulp watch",
     "start": "gulp && node lib/index.js",
     "migrate": "gulp && node lib/migrate.js",
+    "start-mock": "gulp && API_TOKEN_VALIDATE=false node lib/index.js",
     "test": "jest"
   },
   "dependencies": {
@@ -21,6 +22,7 @@
     "globby": "^9.2.0",
     "nanoid": "^2.0.3",
     "passport": "^0.4.0",
+    "passport-anonymous": "^1.0.1",
     "pg": "^7.11.0",
     "pg-hstore": "^2.3.3",
     "postgrator": "^3.10.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "develop": "gulp watch",
     "start": "gulp && node lib/index.js",
     "migrate": "gulp && node lib/migrate.js",
-    "start-mock": "gulp && API_TOKEN_VALIDATE=false node lib/index.js",
+    "start-mock": "gulp && cross-env API_TOKEN_VALIDATE=false node lib/index.js",
     "test": "jest"
   },
   "dependencies": {
@@ -38,6 +38,7 @@
     "@babel/preset-env": "^7.4.5",
     "@babel/register": "^7.4.4",
     "babel-eslint": "^10.0.1",
+    "cross-env": "^5.2.0",
     "eslint": "^5.16.0",
     "eslint-config-prettier": "^4.3.0",
     "eslint-plugin-import": "^2.17.3",

--- a/src/modules/auth.js
+++ b/src/modules/auth.js
@@ -131,7 +131,7 @@ authServer.exchange(
  */
 export const authenticate = () => [
   passport.initialize(),
-  passport.authenticate(validateTokens ? 'bearer' : ['bearer', 'anonymous'], {
+  passport.authenticate(validateTokens ? 'bearer' : 'anonymous', {
     session: false
   })
 ];

--- a/src/modules/auth.js
+++ b/src/modules/auth.js
@@ -4,6 +4,7 @@ import nanoid from 'nanoid';
 import passport from 'passport';
 import oauth2orize from 'oauth2orize';
 import BearerStrategy from 'passport-http-bearer';
+import AnonymousStrategy from 'passport-anonymous';
 
 import configs from './config';
 import models from './database';
@@ -13,7 +14,11 @@ const log = loggers('auth');
 const { UserToken, User } = models;
 
 const { web: webConfig } = configs;
-const { age: tokenAge, length: tokenLength } = webConfig.tokens;
+const {
+  age: tokenAge,
+  length: tokenLength,
+  validate: validateTokens
+} = webConfig.tokens;
 
 const generateToken = () => {
   return nanoid(tokenLength);
@@ -21,6 +26,42 @@ const generateToken = () => {
 
 const compareHashAndPassword = async (hash, password) => {
   return await bcrypt.compare(password, hash);
+};
+
+const authorize = async (token, done) => {
+  try {
+    if (!token.trim()) {
+      return done(
+        new oauth2orize.TokenError('Missing token!', 'invalid_request')
+      );
+    }
+
+    const result = await UserToken.findAll({
+      where: {
+        token
+      },
+      include: [
+        {
+          model: User,
+          required: true
+        }
+      ]
+    });
+
+    if (!Array.isArray(result) || result.length === 0) {
+      return done(
+        new oauth2orize.TokenError('Authentication failed.', 'invalid_grant')
+      );
+    }
+
+    const user = result.shift().User;
+
+    done(null, user, { scope: 'all' });
+  } catch (error) {
+    log.error(error.message);
+    log.error(error.stack);
+    done(new oauth2orize.OAuth2Error(error));
+  }
 };
 
 const authServer = oauth2orize.createServer();
@@ -85,52 +126,21 @@ authServer.exchange(
   })
 );
 
+/**
+ * Provide a wrapper around passport.authenticate with the appropriate strategies selected.
+ */
+export const authenticate = () => [
+  passport.initialize(),
+  passport.authenticate(validateTokens ? 'bearer' : ['bearer', 'anonymous'], {
+    session: false
+  })
+];
+
 export default app => {
   passport.use(
-    new BearerStrategy(async (token, done) => {
-      try {
-        if (!token.trim()) {
-          return done(
-            new oauth2orize.TokenError('Missing token!', 'invalid_request')
-          );
-        }
-
-        const result = await UserToken.findAll({
-          where: {
-            token
-          },
-          include: [
-            {
-              model: User,
-              required: true
-            }
-          ]
-        });
-
-        if (!Array.isArray(result) || result.length === 0) {
-          return done(
-            new oauth2orize.TokenError(
-              'Authentication failed.',
-              'invalid_grant'
-            )
-          );
-        }
-
-        const user = result.shift().User;
-
-        done(null, user, { scope: 'all' });
-      } catch (error) {
-        log.error(error.message);
-        log.error(error.stack);
-        done(new oauth2orize.OAuth2Error(error));
-      }
-    })
+    validateTokens ? new BearerStrategy(authorize) : new AnonymousStrategy()
   );
 
   // allow requests to obtain a token
   app.post('/oauth/token', authServer.token(), authServer.errorHandler());
-
-  // put all API routes behind bearer token auth
-  app.use('/api/*', passport.initialize());
-  app.use('/api/*', passport.authenticate('bearer', { session: false }));
 };

--- a/src/modules/auth.js
+++ b/src/modules/auth.js
@@ -129,12 +129,17 @@ authServer.exchange(
 /**
  * Provide a wrapper around passport.authenticate with the appropriate strategies selected.
  */
-export const authenticate = () => [
-  passport.initialize(),
-  passport.authenticate(validateTokens ? 'bearer' : 'anonymous', {
-    session: false
-  })
-];
+export const authenticate = () => {
+  const { NODE_ENV: environment } = process.env;
+  const useBearerStrategy = environment !== 'test' && validateTokens;
+
+  return [
+    passport.initialize(),
+    passport.authenticate(useBearerStrategy ? 'bearer' : 'anonymous', {
+      session: false
+    })
+  ];
+};
 
 export default app => {
   passport.use(

--- a/src/modules/config.js
+++ b/src/modules/config.js
@@ -17,7 +17,9 @@ export default {
     },
     tokens: {
       length: parseInt(config.API_TOKEN_LENGTH, 10),
-      age: parseInt(config.API_TOKEN_AGE, 10)
+      age: parseInt(config.API_TOKEN_AGE, 10),
+      validate:
+        !config.API_TOKEN_VALIDATE || /^true$/i.test(config.API_TOKEN_VALIDATE)
     }
   },
   database: {

--- a/src/routes/flavor.js
+++ b/src/routes/flavor.js
@@ -1,14 +1,16 @@
 import { Router } from 'express';
 import { check, validationResult } from 'express-validator/check';
 
-import database from '../modules/database';
+import { authenticate } from '../modules/auth';
 import loggers from '../modules/logging';
+import database from '../modules/database';
 
 const router = Router();
 const log = loggers('flavor');
 
 router.get(
   '/:id',
+  authenticate(),
   [
     check('id')
       .isNumeric()

--- a/src/routes/flavor.test.js
+++ b/src/routes/flavor.test.js
@@ -1,5 +1,7 @@
 import express from 'express';
 import request from 'supertest';
+import passport from 'passport';
+import AnonymousStrategy from 'passport-anonymous';
 
 import flavor from './flavor';
 import database from '../modules/database';
@@ -8,6 +10,7 @@ import database from '../modules/database';
 describe('flavor resource', () => {
   const app = express();
 
+  passport.use(new AnonymousStrategy());
   app.use(flavor);
 
   afterAll(() => {


### PR DESCRIPTION
This PR makes the following changes:

* [Adds](https://github.com/gusta-project/api/compare/master...ayan4m1:feature/auth-configuration#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R25) passport-anonymous for auth bypass strategy and [cross-env](https://github.com/gusta-project/api/compare/master...ayan4m1:feature/auth-configuration#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R41) to let us set env vars in package.json scripts
* [Adds](https://github.com/gusta-project/api/compare/master...ayan4m1:feature/auth-configuration#diff-76d9f4cd95a06ef858497eeec21d9c8cR22) the API_TOKEN_VALIDATE boolean env var to the config, defaulting to `true` if the env var is not specified (adding this to the `.env.default` wouldn't work here as we need the environment to override the `.env` file)
* [Refactor](https://github.com/gusta-project/api/compare/master...ayan4m1:feature/auth-configuration#diff-0c9614a084d6e4ba1ccd77842a359e7eR31) the token auth lookup to its own function
* [Export](https://github.com/gusta-project/api/compare/master...ayan4m1:feature/auth-configuration#diff-0c9614a084d6e4ba1ccd77842a359e7eR132) a middleware helper from `auth.js` which injects the appropriate auth strategy into an API request
* [Conditionally](https://github.com/gusta-project/api/compare/master...ayan4m1:feature/auth-configuration#diff-0c9614a084d6e4ba1ccd77842a359e7eR141) choose to specify bearer or anonymous strategy based on config
* [Adds](https://github.com/gusta-project/api/compare/master...ayan4m1:feature/auth-configuration#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R11) a convenience script to start the server up in "mock" or auth-free mode
* [Removes](https://github.com/gusta-project/api/compare/master...ayan4m1:feature/auth-configuration#diff-0c9614a084d6e4ba1ccd77842a359e7eL134) the blanket auth for all routes under `/api` - now routes are free to specify their own authentication needs
* [Call](https://github.com/gusta-project/api/compare/master...ayan4m1:feature/auth-configuration#diff-447a26d00dccc38cd403b5fcb70d99a4R13) the auth helper from the flavor GET route

The practical use of these changes is to allow for conditional bypass of the bearer token authentication. This can make testing and debugging easier.

Finally, the README has been [updated](https://github.com/gusta-project/api/pull/13/files#diff-04c6e90faac2675aa89e2176d2eec7d8L8) because it was out of date with respect to our tooling and stack. I also added a note about starting the authless server.