### PR TITLE
Notify Mattermost via CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  mattermost-notify: bulletlogic/mattermost-notify@0.0.2
+  mattermost-notify: bulletlogic/mattermost-notify@0.0.4
 
 jobs:
   build:
@@ -19,16 +19,12 @@ jobs:
       - image: byrnedo/alpine-curl:latest
     steps:
       - mattermost-notify/notify_on_success:
-          branches: '*'
-          reponame: 'gusta-project/api'
           webhook: '$MATTERMOST_WEBHOOK_API'
   notify_failure:
     docker:
       - image: byrnedo/alpine-curl:latest
     steps:
       - mattermost-notify/notify_on_failure:
-          branches: '*'
-          reponame: 'gusta-project/api'
           webhook: '$MATTERMOST_WEBHOOK_API'
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,8 @@
-version: 2
+version: 2.1
+
+orbs:
+  mattermost-notify: bulletlogic/mattermost-notify@0.0.2
+
 jobs:
   build:
     machine: true
@@ -10,3 +14,33 @@ jobs:
       - store_artifacts:
           path: coverage
           prefix: coverage
+  notify_success:
+    docker:
+      - image: byrnedo/alpine-curl:latest
+    steps:
+      - mattermost-notify/notify_on_success:
+          branches: '*'
+          reponame: 'gusta-project/api'
+          webhook: '$MATTERMOST_WEBHOOK_API'
+  notify_failure:
+    docker:
+      - image: byrnedo/alpine-curl:latest
+    steps:
+      - mattermost-notify/notify_on_failure:
+          branches: '*'
+          reponame: 'gusta-project/api'
+          webhook: '$MATTERMOST_WEBHOOK_API'
+
+workflows:
+  version: 2
+  main_workflow:
+    jobs:
+      - build
+      - notify_success:
+          context: webhooks
+          requires:
+            - build
+      - notify_failure:
+          context: webhooks
+          requires:
+            - build


### PR DESCRIPTION
This PR modifies the CircleCI configuration to use a new orb that sends a webhook notification to our chat server on based on the success or failure of the unit tests.