### PR TITLE
Add expires_in value to token exchange response

### DIFF
--- a/src/modules/auth.js
+++ b/src/modules/auth.js
@@ -98,7 +98,10 @@ authServer.exchange(
           expires: dayjs().add(tokenAge, 'seconds')
         });
 
-        done(null, accessToken, refreshToken, result);
+        done(null, accessToken, refreshToken, {
+          /* eslint-disable-next-line camelcase */
+          expires_in: tokenAge
+        });
       } else {
         done(
           new oauth2orize.AuthorizationError(


### PR DESCRIPTION
Currently the API stores an expiry time for a token in the database, but it does not send this information back to the frontend. This PR adds that in the form of the OAuth standard `expires_in` field, which is an integer number of seconds that the token will be valid for.