### PR TITLE
Convert all decimals into proper millipercent integers

### DIFF
--- a/schema/10.do.millipercent.sql
+++ b/schema/10.do.millipercent.sql
@@ -1,0 +1,13 @@
+alter table preparations_diluents
+  alter millipercent type smallint using millipercent * 1000,
+  alter nicotine_concentration type smallint using nicotine_concentration * 1000;
+
+alter table recipes_diluents
+  alter millipercent type smallint using millipercent * 1000;
+
+alter table recipes_flavors
+  alter millipercent type smallint using millipercent * 1000;
+
+alter table users_flavors
+  alter min_millipercent type smallint using min_millipercent * 1000,
+  alter max_millipercent type smallint using max_millipercent * 1000;

--- a/schema/10.undo.millipercent.sql
+++ b/schema/10.undo.millipercent.sql
@@ -1,0 +1,11 @@
+alter table preparations_diluents
+  alter millipercent type numeric(4, 4) using 0,
+  alter nicotine_concentration type numeric(4, 4) using 0;
+
+alter table recipes_diluents alter millipercent type numeric(4, 4) using 0;
+
+alter table recipes_flavors alter millipercent type numeric(4, 4) using 0;
+
+alter table users_flavors
+  alter min_millipercent type numeric(4, 4) using 0,
+  alter max_millipercent type numeric(4, 4) using 0;


### PR DESCRIPTION
Currently most of the millipercent columns are erroneously declared as `NUMERIC(4, 4)` which is a fractional number. Instead, the goal is to keep the calculator math consistent and fast, and integers are more consistent and fast than decimals. Each millipercent column is now an integer from 0-10000 with 0 representing 0% and 10,000 representing 100%.