### PR TITLE
Return immediately in case of auth error (e.g. db is down)

### DIFF
--- a/src/modules/auth.js
+++ b/src/modules/auth.js
@@ -110,6 +110,7 @@ authServer.exchange(
     } catch (error) {
       log.error(error.message);
       log.error(error.stack);
+      done(error);
     }
   })
 );


### PR DESCRIPTION
When the database is down or some other slow error occurs, the API is holding the HTTP response open and it times out in the browser. This PR calls the auth middleware in case of an error - the way it should have been from the start.