### PR TITLE
Send user ID back with successful auth response

### DIFF
--- a/src/modules/auth.js
+++ b/src/modules/auth.js
@@ -100,7 +100,8 @@ authServer.exchange(
 
         done(null, accessToken, refreshToken, {
           /* eslint-disable-next-line camelcase */
-          expires_in: tokenAge
+          expires_in: tokenAge,
+          userId: user.id
         });
       } else {
         done(


### PR DESCRIPTION
Including the user ID in a successful OAuth token response so that the frontend knows the ID of the logged in user.