### PR TITLE
Allow multiple diluents per preparation

### DIFF
--- a/schema/11.do.prep-diluents-pk.sql
+++ b/schema/11.do.prep-diluents-pk.sql
@@ -1,0 +1,4 @@
+alter table preparations_diluents
+  add column id bigserial not null,
+  drop constraint pk_preparations_diluents,
+  add constraint pk_preparations_diluents primary key (id);

--- a/schema/11.undo.prep-diluents-pk.sql
+++ b/schema/11.undo.prep-diluents-pk.sql
@@ -1,0 +1,4 @@
+alter table preparations_diluents
+  drop constraint pk_preparations_diluents,
+  add constraint pk_preparations_diluents primary key (preparation_id, diluent_id),
+  drop column id;


### PR DESCRIPTION
This PR changes the `preparations_diluents` table from using a composite PK over `(preparation_id, diluent_id)` to a single PK over a new `bigserial` column called `id`. This allows for the storage of preparations which have nicotine base with a PG/VG ratio different than that of the finished liquid.