### PR TITLE
Fix VS Code ctrl-click on index modules

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "module": "esnext",
+    "module": "commonjs",
     "baseUrl": "./src"
   },
   "include": ["src/"]


### PR DESCRIPTION
Currently, you cannot Ctrl-click on imports that are auto-resolved to `index.js` e.g.

```js
import { something } from 'util';
```

Where there is a file `util/index.js`. This PR fixes that by using the correct `module` setting for the JS/TS compiler options.