### PR TITLE
Schema for recipe versioning and flavor/recipe tagging

### DIFF
--- a/schema/12.do.tag-and-version.sql
+++ b/schema/12.do.tag-and-version.sql
@@ -1,3 +1,5 @@
+alter table recipe rename user_id to creator_id;
+
 alter table recipe
   add version int default 1,
   add parent_id bigint default null,

--- a/schema/12.do.tag-and-version.sql
+++ b/schema/12.do.tag-and-version.sql
@@ -26,9 +26,10 @@ create table tags_flavors (
   created timestamp not null default now(),
   creator_id bigint not null,
 
-  constraint pk_tags_flavors primary key (tag_id, flavor_id),
+  constraint pk_tags_flavors primary key (tag_id, flavor_id, creator_id),
   constraint fk1_tags_flavors foreign key (tag_id) references tag (id),
-  constraint fk2_tags_flavors foreign key (flavor_id) references flavor (id)
+  constraint fk2_tags_flavors foreign key (flavor_id) references flavor (id),
+  constraint fk3_tags_flavors foreign key (creator_id) references "user" (id)
 );
 
 create table tags_recipes (
@@ -37,7 +38,8 @@ create table tags_recipes (
   created timestamp not null default now(),
   creator_id bigint not null,
 
-  constraint pk_tags_recipes primary key (tag_id, recipe_id),
+  constraint pk_tags_recipes primary key (tag_id, recipe_id, creator_id),
   constraint fk1_tags_recipes foreign key (tag_id) references tag (id),
-  constraint fk2_tags_recipes foreign key (recipe_id) references tag (id)
+  constraint fk2_tags_recipes foreign key (recipe_id) references tag (id),
+  constraint fk3_tags_recipes foreign key (creator_id) references "user" (id)
 );

--- a/schema/12.do.tag-and-version.sql
+++ b/schema/12.do.tag-and-version.sql
@@ -1,0 +1,41 @@
+alter table recipe
+  add version int default 1,
+  add parent_id bigint default null,
+  add adapted_id bigint default null,
+  add constraint fk2_recipe foreign key (parent_id) references recipe (id),
+  add constraint fk3_recipe foreign key (adapted_id) references recipe (id);
+
+create table tag (
+  id bigserial not null,
+  name varchar(200) not null,
+  slug varchar(200) not null,
+  created timestamp not null default now(),
+  creator_id bigint not null,
+
+  constraint pk_tag primary key (id),
+  constraint uk1_tag unique (name),
+  constraint uk2_tag unique (slug),
+  constraint fk1_tag foreign key (creator_id) references "user" (id)
+);
+
+create table tags_flavors (
+  tag_id bigint not null,
+  flavor_id bigint not null,
+  created timestamp not null default now(),
+  creator_id bigint not null,
+
+  constraint pk_tags_flavors primary key (tag_id, flavor_id),
+  constraint fk1_tags_flavors foreign key (tag_id) references tag (id),
+  constraint fk2_tags_flavors foreign key (flavor_id) references flavor (id)
+);
+
+create table tags_recipes (
+  tag_id bigint not null,
+  recipe_id bigint not null,
+  created timestamp not null default now(),
+  creator_id bigint not null,
+
+  constraint pk_tags_recipes primary key (tag_id, recipe_id),
+  constraint fk1_tags_recipes foreign key (tag_id) references tag (id),
+  constraint fk2_tags_recipes foreign key (recipe_id) references tag (id)
+);

--- a/schema/12.undo.tag-and-version.sql
+++ b/schema/12.undo.tag-and-version.sql
@@ -6,3 +6,5 @@ alter table recipe
   drop column parent_id,
   drop column adapted_id,
   drop column version;
+
+alter table recipe rename creator_id to user_id;

--- a/schema/12.undo.tag-and-version.sql
+++ b/schema/12.undo.tag-and-version.sql
@@ -1,0 +1,8 @@
+drop table tags_flavors;
+drop table tags_recipes;
+drop table tag;
+
+alter table recipe
+  drop column parent_id,
+  drop column adapted_id,
+  drop column version;

--- a/src/models/recipe.js
+++ b/src/models/recipe.js
@@ -8,7 +8,23 @@ module.exports = (sequelize, DataTypes) => {
         primaryKey: true,
         autoIncrement: true
       },
-      userId: {
+      parentId: {
+        type: DataTypes.BIGINT,
+        allowNull: true,
+        references: {
+          model: sequelize.Recipe,
+          key: 'id'
+        }
+      },
+      adaptedId: {
+        type: DataTypes.BIGINT,
+        allowNull: true,
+        references: {
+          model: sequelize.Recipe,
+          key: 'id'
+        }
+      },
+      creatorId: {
         type: DataTypes.BIGINT,
         allowNull: false,
         references: {
@@ -44,6 +60,8 @@ module.exports = (sequelize, DataTypes) => {
   );
 
   Recipe.associate = function(models) {
+    this.hasOne(models.Recipe, { as: 'Parent', foreignKey: 'parentId' });
+    this.hasOne(models.Recipe, { as: 'AdaptedFrom', foreignKey: 'adaptedId' });
     this.belongsTo(models.User, { foreignKey: 'userId' });
     this.belongsTo(models.UserProfile, {
       foreignKey: 'userId',

--- a/src/models/tag.js
+++ b/src/models/tag.js
@@ -39,6 +39,18 @@ module.exports = (sequelize, DataTypes) => {
     this.hasOne(models.User, {
       foreignKey: 'creatorId'
     });
+    this.belongsToMany(models.TagsFlavors, {
+      as: 'Flavors',
+      through: models.Flavor,
+      foreignKey: 'tagId',
+      otherKey: 'flavorId'
+    });
+    this.belongsToMany(models.TagsRecipes, {
+      as: 'Recipes',
+      through: models.Recipe,
+      foreignKey: 'tagId',
+      otherKey: 'recipeId'
+    });
   };
 
   return Tag;

--- a/src/models/tag.js
+++ b/src/models/tag.js
@@ -1,0 +1,45 @@
+module.exports = (sequelize, DataTypes) => {
+  const Tag = sequelize.define(
+    'Tag',
+    {
+      id: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        primaryKey: true,
+        autoIncrement: true
+      },
+      name: {
+        type: DataTypes.STRING,
+        allowNull: false
+      },
+      slug: {
+        type: DataTypes.STRING,
+        allowNull: false
+      },
+      created: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        defaultValue: DataTypes.NOW
+      },
+      creatorId: {
+        type: DataTypes.BIGINT,
+        allowNull: false
+      }
+    },
+    {
+      sequelize,
+      underscored: true,
+      tableName: 'tag',
+      createdAt: 'created',
+      updatedAt: false
+    }
+  );
+
+  Tag.associate = function(models) {
+    this.hasOne(models.User, {
+      foreignKey: 'creatorId'
+    });
+  };
+
+  return Tag;
+};

--- a/src/models/tagsFlavors.js
+++ b/src/models/tagsFlavors.js
@@ -1,0 +1,49 @@
+module.exports = (sequelize, DataTypes) => {
+  const TagsFlavors = sequelize.define(
+    'TagsFlavors',
+    {
+      tagId: {
+        type: DataTypes.BIGINT,
+        allowNull: false,
+        primaryKey: true,
+        references: {
+          model: sequelize.Tag,
+          key: 'id'
+        }
+      },
+      flavorId: {
+        type: DataTypes.BIGINT,
+        allowNull: false,
+        primaryKey: true,
+        references: {
+          model: sequelize.Flavor,
+          key: 'id'
+        }
+      },
+      created: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        defaultValue: DataTypes.NOW
+      },
+      creatorId: {
+        type: DataTypes.BIGINT,
+        allowNull: false
+      }
+    },
+    {
+      sequelize,
+      underscored: true,
+      tableName: 'tags_flavors',
+      createdAt: 'created',
+      updatedAt: false
+    }
+  );
+
+  TagsFlavors.associate = function(models) {
+    this.belongsTo(models.Tag, { foreignKey: 'tagId' });
+    this.belongsTo(models.User, { foreignKey: 'creatorId' });
+    this.belongsTo(models.Flavor, { foreignKey: 'flavorId' });
+  };
+
+  return TagsFlavors;
+};

--- a/src/models/tagsRecipes.js
+++ b/src/models/tagsRecipes.js
@@ -1,0 +1,49 @@
+module.exports = (sequelize, DataTypes) => {
+  const TagsRecipes = sequelize.define(
+    'TagsRecipes',
+    {
+      tagId: {
+        type: DataTypes.BIGINT,
+        allowNull: false,
+        primaryKey: true,
+        references: {
+          model: sequelize.Tag,
+          key: 'id'
+        }
+      },
+      recipeId: {
+        type: DataTypes.BIGINT,
+        allowNull: false,
+        primaryKey: true,
+        references: {
+          model: sequelize.Recipe,
+          key: 'id'
+        }
+      },
+      created: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        defaultValue: DataTypes.NOW
+      },
+      creatorId: {
+        type: DataTypes.BIGINT,
+        allowNull: false
+      }
+    },
+    {
+      sequelize,
+      underscored: true,
+      tableName: 'tags_flavors',
+      createdAt: 'created',
+      updatedAt: false
+    }
+  );
+
+  TagsRecipes.associate = function(models) {
+    this.belongsTo(models.Tag, { foreignKey: 'tagId' });
+    this.belongsTo(models.User, { foreignKey: 'creatorId' });
+    this.belongsTo(models.Recipe, { foreignKey: 'recipeId' });
+  };
+
+  return TagsRecipes;
+};


### PR DESCRIPTION
This PR adds schema which allows users to tag flavors and recipes with arbitrary strings. It also modifies the `recipe` table so that recipes can be versioned. To do this, it adds a `version` column which is intended to be a monotonically increasing integer starting at 1. Each subsequent version has a `parent_id` set to the prior version's recipe ID.