### PR TITLE
Add missing unique constraint on role.name

### DIFF
--- a/schema/13.do.unique-role-name.sql
+++ b/schema/13.do.unique-role-name.sql
@@ -1,0 +1,1 @@
+alter table "role" add constraint uk1_role unique (name);

--- a/schema/13.undo.unique-role-name.sql
+++ b/schema/13.undo.unique-role-name.sql
@@ -1,0 +1,1 @@
+alter table "role" drop constraint uk1_role;


### PR DESCRIPTION
This PR adds a miss caught by @daviddyess - namely, there is no unique constraint on the role `name` column, which could lead to complicated mistakes. Make sure that you manually deduplicate before attempting migration!