### PR TITLE
Fix models still using userId instead of creatorId

### DIFF
--- a/src/models/recipe.js
+++ b/src/models/recipe.js
@@ -66,7 +66,7 @@ module.exports = (sequelize, DataTypes) => {
   Recipe.associate = function(models) {
     this.hasOne(models.Recipe, { as: 'Parent', foreignKey: 'parentId' });
     this.hasOne(models.Recipe, { as: 'AdaptedFrom', foreignKey: 'adaptedId' });
-    this.belongsTo(models.User, { foreignKey: 'userId' });
+    this.belongsTo(models.User, { foreignKey: 'creatorId' });
     this.belongsTo(models.UserProfile, {
       foreignKey: 'userId',
       sourceKey: 'userId'

--- a/src/models/recipe.js
+++ b/src/models/recipe.js
@@ -8,6 +8,10 @@ module.exports = (sequelize, DataTypes) => {
         primaryKey: true,
         autoIncrement: true
       },
+      version: {
+        type: DataTypes.INTEGER,
+        allowNull: false
+      },
       parentId: {
         type: DataTypes.BIGINT,
         allowNull: true,

--- a/src/models/tag.js
+++ b/src/models/tag.js
@@ -37,7 +37,8 @@ module.exports = (sequelize, DataTypes) => {
 
   Tag.associate = function(models) {
     this.hasOne(models.User, {
-      foreignKey: 'creatorId'
+      foreignKey: 'id',
+      sourceKey: 'creatorId'
     });
     this.belongsToMany(models.TagsFlavors, {
       as: 'Flavors',

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -40,7 +40,7 @@ module.exports = (sequelize, DataTypes) => {
       foreignKey: 'userId'
     });
     this.hasMany(models.Recipe, {
-      foreignKey: 'userId'
+      foreignKey: 'creatorId'
     });
     this.hasMany(models.Preparation, {
       foreignKey: 'userId'


### PR DESCRIPTION
Some models were trying to use the incorrect foreign key resulting in queries like:

> SELECT "id", "email_address" AS "emailAddress", "password", "created", "activation_code" AS "activationCode", "creator_id" AS "creatorId" FROM "user" AS "User" WHERE "User"."email_address" = 'someone@email.org' AND "User"."activation_code" IS NULL;

This results in column not found errors because creator_id is not a column on the user table. [This change](https://github.com/gusta-project/api/compare/master...ayan4m1:fix/user-model?expand=1#diff-9cde3d777f4c1ebe697276b63c7aea1bR41) fixes that issue, while [this one](https://github.com/gusta-project/api/compare/master...ayan4m1:fix/user-model?expand=1#diff-9cde3d777f4c1ebe697276b63c7aea1bR41) and [this one](https://github.com/gusta-project/api/compare/master...ayan4m1:fix/user-model?expand=1#diff-9dc1f788cd7f661a552c2e001c185d20R69) tie up loose ends.
