### PR TITLE
Fix queries and empty checks in routes

### DIFF
--- a/src/routes/data.js
+++ b/src/routes/data.js
@@ -38,7 +38,7 @@ router.get(
         }
       });
 
-      if (!result || result.length === 0) {
+      if (!result) {
         return res.status(204).end();
       }
 
@@ -205,7 +205,7 @@ router.get('/suppliers', authenticate(), async (req, res) => {
   try {
     const result = await DataSupplier.findAll();
 
-    if (!result || result.length === 0) {
+    if (!Array.isArray(result) || result.length === 0) {
       return res.status(204).end();
     }
 
@@ -234,7 +234,7 @@ router.get(
     try {
       const result = await SchemaVersion.findAll();
 
-      if (!result || result.length === 0) {
+      if (!Array.isArray(result) || result.length === 0) {
         return res.status(204).end();
       }
 

--- a/src/routes/diluent.js
+++ b/src/routes/diluent.js
@@ -38,7 +38,7 @@ router.get(
         }
       });
 
-      if (!result || result.length === 0) {
+      if (!result) {
         return res.status(204).end();
       }
 

--- a/src/routes/diluents.js
+++ b/src/routes/diluents.js
@@ -44,7 +44,7 @@ router.get(
         offset
       });
 
-      if (result.length === 0) {
+      if (!Array.isArray(result) || result.length === 0) {
         return res.status(204).end();
       }
 

--- a/src/routes/flavor.js
+++ b/src/routes/flavor.js
@@ -44,7 +44,7 @@ router.get(
         ]
       });
 
-      if (!result || result.length === 0) {
+      if (!result) {
         return res.status(204).end();
       }
 
@@ -253,7 +253,7 @@ router.get(
         ]
       });
 
-      if (!result || result.length === 0) {
+      if (!Array.isArray(result) || result.length === 0) {
         return res.status(204).end();
       }
 
@@ -308,7 +308,7 @@ router.get(
         ]
       });
 
-      if (!result || result.length === 0) {
+      if (!result) {
         return res.status(204).end();
       }
 

--- a/src/routes/flavors.js
+++ b/src/routes/flavors.js
@@ -50,7 +50,7 @@ router.get(
         ]
       });
 
-      if (result.length === 0) {
+      if (!Array.isArray(result) || result.length === 0) {
         return res.status(204).end();
       }
 

--- a/src/routes/preparation.js
+++ b/src/routes/preparation.js
@@ -13,8 +13,6 @@ const {
   Preparation,
   PreparationsDiluents,
   Recipe,
-  RecipesDiluents,
-  RecipesFlavors,
   UserProfile
 } = models;
 
@@ -56,36 +54,18 @@ router.get(
             required: true,
             include: [
               {
-                model: RecipesFlavors,
-                required: true,
-                include: [
-                  {
-                    model: Flavor,
-                    required: true
-                  }
-                ]
+                model: Flavor,
+                as: 'Flavors'
               },
               {
-                model: RecipesDiluents,
-                required: true,
-                include: [
-                  {
-                    model: Diluent,
-                    required: true
-                  }
-                ]
+                model: Diluent,
+                as: 'Diluents'
               }
             ]
           },
           {
-            model: PreparationsDiluents,
-            required: true,
-            include: [
-              {
-                model: Diluent,
-                required: true
-              }
-            ]
+            model: Diluent,
+            as: 'Diluents'
           }
         ]
       });

--- a/src/routes/preparation.js
+++ b/src/routes/preparation.js
@@ -90,7 +90,7 @@ router.get(
         ]
       });
 
-      if (result.length === 0) {
+      if (!result) {
         return res.status(204).end();
       }
 
@@ -145,7 +145,7 @@ router.post(
         }
       });
 
-      if (recipeCheck.length === 0) {
+      if (!recipeCheck) {
         // Recipe doesn't exist
         return res.status(204).end();
       }
@@ -221,7 +221,7 @@ router.put(
         }
       });
 
-      if (preparationCheck.length === 0) {
+      if (!preparationCheck) {
         // Preparation doesn't exist
         return res.status(204).end();
       }
@@ -282,10 +282,6 @@ router.put(
 
       const result = { preparationResult, diluentResult };
 
-      if (result.length === 0) {
-        return res.status(204).end();
-      }
-
       res.type('application/json');
       res.json(result);
     } catch (error) {
@@ -330,10 +326,6 @@ router.delete(
       });
 
       const result = { preparationResult, diluentResult };
-
-      if (result.length === 0) {
-        return res.status(204).end();
-      }
 
       res.type('application/json');
       res.json(result);

--- a/src/routes/preparations.js
+++ b/src/routes/preparations.js
@@ -44,7 +44,7 @@ router.get(
         offset
       });
 
-      if (result.length === 0) {
+      if (!Array.isArray(result) || result.length === 0) {
         return res.status(204).end();
       }
 

--- a/src/routes/recipe.js
+++ b/src/routes/recipe.js
@@ -72,7 +72,7 @@ router.get(
         ]
       });
 
-      if (result.length === 0) {
+      if (!result) {
         return res.status(204).end();
       }
 
@@ -205,7 +205,7 @@ router.put(
         }
       });
 
-      if (recipeCheck.length === 0) {
+      if (!recipeCheck) {
         // Recipe doesn't exist
         return res.status(204).end();
       }
@@ -292,10 +292,6 @@ router.put(
 
       const result = { recipeResult, diluentResult, flavorResult };
 
-      if (result.length === 0) {
-        return res.status(204).end();
-      }
-
       res.type('application/json');
       res.json(result);
     } catch (error) {
@@ -347,10 +343,6 @@ router.delete(
       });
 
       const result = { recipeResult, diluentResult, flavorResult };
-
-      if (result.length === 0) {
-        return res.status(204).end();
-      }
 
       res.type('application/json');
       res.json(result);

--- a/src/routes/recipe.js
+++ b/src/routes/recipe.js
@@ -50,24 +50,12 @@ router.get(
             required: true
           },
           {
-            model: RecipesFlavors,
-            required: true,
-            include: [
-              {
-                model: Flavor,
-                required: true
-              }
-            ]
+            model: Flavor,
+            as: 'Flavors'
           },
           {
-            model: RecipesDiluents,
-            required: true,
-            include: [
-              {
-                model: Diluent,
-                required: true
-              }
-            ]
+            model: Diluent,
+            as: 'Diluents'
           }
         ]
       });

--- a/src/routes/recipes.js
+++ b/src/routes/recipes.js
@@ -44,7 +44,7 @@ router.get(
         offset
       });
 
-      if (result.length === 0) {
+      if (!Array.isArray(result) || result.length === 0) {
         return res.status(204).end();
       }
 

--- a/src/routes/role.js
+++ b/src/routes/role.js
@@ -38,7 +38,7 @@ router.get(
         }
       });
 
-      if (!result || result.length === 0) {
+      if (!result) {
         return res.status(204).end();
       }
 

--- a/src/routes/roles.js
+++ b/src/routes/roles.js
@@ -16,7 +16,7 @@ router.get('/', authenticate(), async (req, res) => {
   try {
     const result = await Role.findAll();
 
-    if (!result || result.length === 0) {
+    if (!Array.isArray(result) || result.length === 0) {
       return res.status(204).end();
     }
 

--- a/src/routes/user.js
+++ b/src/routes/user.js
@@ -47,7 +47,7 @@ router.get(
         }
       });
 
-      if (!result || result.length === 0) {
+      if (!result) {
         return res.status(204).end();
       }
 
@@ -91,7 +91,7 @@ router.get(
         }
       });
 
-      if (result.length === 0) {
+      if (!result) {
         return res.status(204).end();
       }
 
@@ -181,7 +181,7 @@ router.get(
         }
       });
 
-      if (result.length === 0) {
+      if (!Array.isArray(result) || result.length === 0) {
         return res.status(204).end();
       }
 
@@ -235,7 +235,7 @@ router.get(
         ]
       });
 
-      if (result.length === 0) {
+      if (!Array.isArray(result) || result.length === 0) {
         return res.status(204).end();
       }
 
@@ -296,7 +296,7 @@ router.get(
         ]
       });
 
-      if (result.length === 0) {
+      if (!Array.isArray(result) || result.length === 0) {
         return res.status(204).end();
       }
 
@@ -489,7 +489,7 @@ router.get(
         ]
       });
 
-      if (result.length === 0) {
+      if (!Array.isArray(result) || result.length === 0) {
         return res.status(204).end();
       }
 
@@ -542,7 +542,7 @@ router.get(
         ]
       });
 
-      if (result.length === 0) {
+      if (!result) {
         return res.status(204).end();
       }
 

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -44,7 +44,7 @@ router.get(
         offset
       });
 
-      if (result.length === 0) {
+      if (!Array.isArray(result) || result.length === 0) {
         return res.status(204).end();
       }
 
@@ -92,7 +92,7 @@ router.get(
         offset
       });
 
-      if (result.length === 0) {
+      if (!Array.isArray(result) || result.length === 0) {
         return res.status(204).end();
       }
 
@@ -154,7 +154,7 @@ router.get(
         offset
       });
 
-      if (!result || result.length === 0) {
+      if (!Array.isArray(result) || result.length === 0) {
         return res.status(204).end();
       }
 

--- a/src/routes/vendor.js
+++ b/src/routes/vendor.js
@@ -242,7 +242,7 @@ router.get(
         ]
       });
 
-      if (!result || result.length === 0) {
+      if (!Array.isArray(result) || result.length === 0) {
         return res.status(204).end();
       }
 
@@ -297,7 +297,7 @@ router.get(
         ]
       });
 
-      if (!result || result.length === 0) {
+      if (!result) {
         return res.status(204).end();
       }
 

--- a/src/routes/vendors.js
+++ b/src/routes/vendors.js
@@ -44,7 +44,7 @@ router.get(
         offset
       });
 
-      if (result.length === 0) {
+      if (!Array.isArray(result) || result.length === 0) {
         return res.status(204).end();
       }
 


### PR DESCRIPTION
This PR makes two changes.

I went over all of the routes and looked for places where we were either treating the results of `findOne` as an array and replaced these checks with simple null checks instead, because findOne never returns an array. I also added `Array.isArray(result)` assertions to all of the calls to `findAll` before checking its `length` property.

The other change is to some of the queries that were using nested `include` sections in order to query through models. Now that we have `belongsToMany` associations, that is not necessary (or valid since the models aren't directly associated anymore). I changed these queries to use the correct associations, and removed some instances of `required: true` on models that we don't want to inner join to.